### PR TITLE
Merge blocking ADC approach into updated mainline

### DIFF
--- a/fsae-vehicle-fw/src/peripherals/adc.cpp
+++ b/fsae-vehicle-fw/src/peripherals/adc.cpp
@@ -1,19 +1,129 @@
 // Anteater Electric Racing, 2025
 
-#include "peripherals/adc.h"
-#include "callbacks.h"
+#include <ADC.h>
+#include <stdint.h>
+#include "adc.h"
+#include "./vehicle/telemetry.h"
+#include <chrono>
+#include <arduino_freertos.h>
 #include "utils/utils.h"
+#include "vehicle/bse.h"
+#include "vehicle/apps.h"
+#include "vehicle/faults.h"
+#include "vehicle/telemetry.h"
+#include "vehicle/motor.h"
 
-void ADC0_Init() {
-    adc->adc0->setAveraging(2); // set number of averages
-    adc->adc0->setResolution(ADC_RESOLUTION); // set bits of resolution
-    adc->adc0->setConversionSpeed(ADC_CONVERSION_SPEED::LOW_SPEED); // change the conversion speed
+# ifndef EV_ADC
+# define EV_ADC
+
+#define THREAD_ADC_STACK_SIZE 128
+#define THREAD_ADC_PRIORITY 2
+#define THREAD_ADC_TELEMETRY_PRIORITY 1
+
+#define LOGIC_LEVEL_V 3.3
+#define ADC_RESOLUTION 10
+#define adc0_MAX_VALUE (1 << ADC_RESOLUTION) - 1
+
+enum SensorIndexesADC0 { // TODO: Update with real values
+    APPS_1_INDEX,
+    APPS_2_INDEX,
+    BSE_1_INDEX,
+    BSE_2_INDEX,
+    SUSP_TRAV_LINPOT1,
+    SUSP_TRAV_LINPOT2,
+    SUSP_TRAV_LINPOT3,
+    SUSP_TRAV_LINPOT4
+};
+
+enum SensorIndexesADC1 { // TODO: Update with real values
+    APPS_1_INDEX2,
+    APPS_2_INDEX2,
+    BSE_1_INDEX2,
+    BSE_2_INDEX2,
+    SUSP_TRAV_LINPOT12,
+    SUSP_TRAV_LINPOT22,
+    SUSP_TRAV_LINPOT32,
+    SUSP_TRAV_LINPOT42
+};
+
+uint16_t adc0Pins[SENSOR_PIN_AMT_ADC0] = {A0, A1, A2, A3, A4, A5, A6, A7}; // A4, A4, 18, 17, 17, 17, 17}; // real values: {21, 24, 25, 19, 18, 14, 15, 17};
+volatile uint16_t adc0Reads[SENSOR_PIN_AMT_ADC0];
+
+uint16_t adc1Pins[SENSOR_PIN_AMT_ADC1] = {A7, A6, A5, A4, A3, A2, A1, A0}; // A4, A4, 18, 17, 17, 17, 17}; // real values: {21, 24, 25, 19, 18, 14, 15, 17};
+volatile uint16_t adc1Reads[SENSOR_PIN_AMT_ADC1];
+
+ADC *adc = new ADC();
+
+void ADC_Init() {
+
+    // ADC 0
+    adc->adc0->setAveraging(1); // set number of averages
+    adc->adc0->setResolution(12); // set bits of resolution
+    adc->adc0->setConversionSpeed(ADC_CONVERSION_SPEED::ADACK_20); // change the conversion speed
     adc->adc0->setSamplingSpeed(ADC_SAMPLING_SPEED::LOW_SPEED); // change the sampling speed
+
+    // ADC 1
+    adc->adc1->setAveraging(1); // set number of averages
+    adc->adc1->setResolution(12); // set bits of resolution
+    adc->adc1->setConversionSpeed(ADC_CONVERSION_SPEED::ADACK_20); // change the conversion speed
+    adc->adc1->setSamplingSpeed(ADC_SAMPLING_SPEED::LOW_SPEED); // change the sampling speed
+
+    Serial.println("Done initializing ADCs");
 }
 
-void ADC1_Init() {
-    adc->adc1->setAveraging(1); // set number of averages
-    adc->adc1->setResolution(ADC_RESOLUTION); // set bits of resolution
-    adc->adc1->setConversionSpeed(ADC_CONVERSION_SPEED::LOW_SPEED); // change the conversion speed
-    adc->adc1->setSamplingSpeed(ADC_SAMPLING_SPEED::LOW_SPEED); // change the sampling speed
+void threadADC( void *pvParameters );
+
+void ADC_Begin() {
+    xTaskCreate(threadADC, "threadADC", THREAD_ADC_STACK_SIZE, NULL, THREAD_ADC_PRIORITY, NULL);
+    Serial.print("beginning adc task");
 }
+
+void threadADC( void *pvParameters ){
+    Serial.print("beginning adc thread");
+    TickType_t lastWakeTime = xTaskGetTickCount();
+    const TickType_t xFrequency = 1;
+
+    while(true){
+        vTaskDelayUntil(&lastWakeTime, xFrequency);
+        for(uint16_t currentIndexADC0 = 0; currentIndexADC0 < SENSOR_PIN_AMT_ADC0; ++currentIndexADC0){
+            uint16_t currentPinADC0 = adc0Pins[currentIndexADC0];
+            uint16_t adcRead = adc->adc1->analogRead(currentPinADC0); // in callbacks.h
+            adc0Reads[currentIndexADC0] = adcRead;
+        }
+
+        for(uint16_t currentIndexADC1 = 0; currentIndexADC1 < SENSOR_PIN_AMT_ADC1; ++currentIndexADC1){
+            uint16_t currentPinADC1 = adc1Pins[currentIndexADC1];
+            uint16_t adcRead = adc->adc1->analogRead(currentPinADC1); // in callbacks.h
+            adc1Reads[currentIndexADC1] = adcRead;
+        }
+        bool rtmButton = digitalRead(RTM_BUTTON_PIN);
+        bool wheelSpeed1 = digitalRead(WHEEL_SPEED_1_PIN);
+        bool wheelSpeed2 = digitalRead(WHEEL_SPEED_2_PIN);
+
+        // Update each sensors data
+        APPS_UpdateData(adc0Reads[APPS_1_INDEX], adc0Reads[APPS_2_INDEX]);
+        BSE_UpdateData(adc0Reads[BSE_1_INDEX], adc0Reads[BSE_2_INDEX]);
+
+        // Handle any faults that were raised
+        Faults_HandleFaults();
+
+        Motor_UpdateMotor();
+
+        // Update telemetry data
+        TelemetryData telemetryData = {
+            .APPS_Travel = APPS_GetAPPSReading(),
+            .BSEFront_PSI = BSE_GetBSEReading()->bseFront_PSI,
+            .BSERear_PSI = BSE_GetBSEReading()->bseRear_PSI,
+            .motorState = Motor_GetState(),
+        };
+
+        telemetryData.debug[0] = APPS_GetAPPSReading1();
+        telemetryData.debug[1] = APPS_GetAPPSReading2();
+
+
+        Telemetry_UpdateData(&telemetryData);
+            Telemetry_UpdateADCData(adc0Reads, adc1Reads);
+        }
+}
+
+# endif

--- a/fsae-vehicle-fw/src/peripherals/adc.h
+++ b/fsae-vehicle-fw/src/peripherals/adc.h
@@ -1,21 +1,22 @@
 // Anteater Electric Racing, 2025
+#ifndef ADC_EV_H
+#define ADC_EV_H
 
 #include <ADC.h>
 #define SENSOR_PIN_AMT_ADC0 8
 #define SENSOR_PIN_AMT_ADC1 8
 
-// rtm: 15, bse1: 16, bse2: 17, apps1: 18, apps2: 19, susp1: 20, susp2: 21, susp3: 22, susp4: 23
+extern uint16_t adc0Pins[SENSOR_PIN_AMT_ADC0];
+extern volatile uint16_t adc0Index;
+extern volatile uint16_t adc0Reads[SENSOR_PIN_AMT_ADC0];
 
-// note: change inputs for potentiometers to A0 (14) and A1 (15)
-static uint16_t adc0Pins[SENSOR_PIN_AMT_ADC0] = {18, 19, 16, 17, 20, 21, 22, 23}; // A4, A4, 18, 17, 17, 17, 17}; // real values: {21, 24, 25, 19, 18, 14, 15, 17};
-static volatile uint16_t adc0Index = 0;
-static volatile uint16_t adc0Reads[SENSOR_PIN_AMT_ADC0];
+extern uint16_t adc1Pins[SENSOR_PIN_AMT_ADC1];
+extern volatile uint16_t adc1Index;
+extern volatile uint16_t adc1Reads[SENSOR_PIN_AMT_ADC1];
 
-static uint16_t adc1Pins[SENSOR_PIN_AMT_ADC1] = {A7, A6, A5, A4, A3, A2, A1, A0}; // A4, A4, 18, 17, 17, 17, 17}; // real values: {21, 24, 25, 19, 18, 14, 15, 17};
-static volatile uint16_t adc1Index = 0;
-static volatile uint16_t adc1Reads[SENSOR_PIN_AMT_ADC1];
+extern ADC *adc;
 
-static ADC *adc = new ADC();
+void ADC_Init();
+void ADC_Begin();
 
-void ADC0_Init();
-void ADC1_Init();
+#endif // ADC_EV_H

--- a/fsae-vehicle-fw/src/peripherals/peripherals.cpp
+++ b/fsae-vehicle-fw/src/peripherals/peripherals.cpp
@@ -1,16 +1,11 @@
 // Anteater Electric Racing, 2025
-
 #include "peripherals/adc.h"
 #include "peripherals/can.h"
 #include "peripherals/gpio.h"
 #include "peripherals/peripherals.h"
-#include "peripherals/timer.h"
 
 void Peripherals_Init() {
-    GPIO_Init();
-    ADC0_Init();
-    ADC1_Init();
+    ADC_Init();
+    ADC_Begin();
     CAN_Init();
-
-    Timer_StartADCScan();
 }

--- a/fsae-vehicle-fw/src/peripherals/timer.cpp
+++ b/fsae-vehicle-fw/src/peripherals/timer.cpp
@@ -1,6 +1,0 @@
-#include "peripherals/timer.h"
-#include "callbacks.h"
-
-void Timer_StartADCScan(){
-    readPinTimer.begin(StartADCScanCallback, 1000);
-}

--- a/fsae-vehicle-fw/src/peripherals/timer.h
+++ b/fsae-vehicle-fw/src/peripherals/timer.h
@@ -1,5 +1,0 @@
-
-#include <IntervalTimer.h>
-
-void Timer_StartADCScan();
-static IntervalTimer readPinTimer;

--- a/fsae-vehicle-fw/src/vehicle/telemetry.cpp
+++ b/fsae-vehicle-fw/src/vehicle/telemetry.cpp
@@ -1,26 +1,82 @@
 // Anteater Electric Racing, 2025
+#define THREAD_CAN_TELEMETRY_STACK_SIZE 128
+#define THREAD_CAN_TELEMETRY_PRIORITY 2
 
 #include "telemetry.h"
+#include <FlexCAN_T4.h>
+#include <isotp.h>
+#include <arduino_freertos.h>
+#include <semphr.h>
 
-TelemetryData telemetryData;
+SemaphoreHandle_t xSemaphore = xSemaphoreCreateMutex();
+
+// TODO: Update IDs to be more logical values
+const uint32_t canid = 0x666;
+const uint32_t request = 0x777;
+TelemetryData telemetryDataCAN;
+isotp<RX_BANKS_16, 512> tp;
+FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_16> can2; // TODO: Figure out actual values for send and recieve
+
+void threadTelemetryCAN( void *pvParameters );
 
 void Telemetry_Init() {
-    // fill with reasonable default values
-    telemetryData = {
-        .APPS_Travel = 0,
-        .BSEFront_PSI = 0,
-        .BSERear_PSI = 0,
-
+    // TODO: Update initialization
+    telemetryDataCAN = {
         .accumulatorVoltage = 0,
         .accumulatorTemp_F = 0,
         .tractiveSystemVoltage = 0
     };
+
+    can2.begin();
+    can2.setBaudRate(1000000);
+    can2.setTX(DEF);
+    can2.setRX(DEF);
+    can2.enableFIFO();
+    can2.enableFIFOInterrupt();
+    can2.setMaxMB(16);
+    tp.begin();
+    tp.setWriteBus(&can2); /* we write to this bus */
+
+}
+
+void Telemetry_Begin() {
+    xTaskCreate(threadTelemetryCAN, "threadTelemetryCAN", THREAD_CAN_TELEMETRY_STACK_SIZE, NULL, THREAD_CAN_TELEMETRY_PRIORITY, NULL);
+}
+
+void threadTelemetryCAN(void *pvParameters){
+    uint8_t serializedTelemetryBuf[sizeof(TelemetryData)];
+    TickType_t lastWakeTime = xTaskGetTickCount();
+    const TickType_t xFrequency = 1;
+    while(true){
+        vTaskDelayUntil(&lastWakeTime, xFrequency);
+        Serial.print("Semaphor take successful");
+        xSemaphoreTake(xSemaphore, (TickType_t) 1000);
+        Telemetry_SerializeData(telemetryDataCAN, serializedTelemetryBuf);
+        xSemaphoreGive(xSemaphore);
+
+        ISOTP_data config;
+        config.id = 0x666;
+        config.flags.extended = 0; /* standard frame */
+        config.separation_time = 10; /* time between back-to-back frames in millisec */
+        tp.write(config, serializedTelemetryBuf, sizeof(serializedTelemetryBuf));
+    }
+}
+
+void Telemetry_SerializeData(TelemetryData data, uint8_t* serializedTelemetryBuf){
+    memcpy(serializedTelemetryBuf, &data, sizeof(data));
 }
 
 TelemetryData const* Telemetry_GetData() {
-    return &telemetryData;
+    return &telemetryDataCAN;
 }
 
 void Telemetry_UpdateData(TelemetryData* data) {
-    telemetryData = *data;
+    telemetryDataCAN = *data;
+}
+
+void Telemetry_UpdateADCData(volatile uint16_t* adc0reads, volatile uint16_t* adc1reads){
+    xSemaphoreTake(xSemaphore, (TickType_t) 1000);
+    memcpy(telemetryDataCAN.adc0Reads, (const uint16_t*)adc0reads, sizeof(telemetryDataCAN.adc0Reads));
+    memcpy(telemetryDataCAN.adc1Reads, (const uint16_t*)adc1reads, sizeof(telemetryDataCAN.adc1Reads));
+    xSemaphoreGive(xSemaphore);
 }

--- a/fsae-vehicle-fw/src/vehicle/telemetry.h
+++ b/fsae-vehicle-fw/src/vehicle/telemetry.h
@@ -2,10 +2,10 @@
 #pragma once
 
 #include <stdint.h>
-
 #include "motor.h"
+#include <peripherals/adc.h>
 
-typedef struct {
+struct TelemetryData{
     float APPS_Travel; // APPS travel in %
 
     float BSEFront_PSI; // front brake pressure in PSI
@@ -19,9 +19,16 @@ typedef struct {
     MotorState motorState; // Motor state
 
     float debug[4]; // Debug data
-} TelemetryData;
+    uint16_t adc0Reads[SENSOR_PIN_AMT_ADC0];
+    uint16_t adc1Reads[SENSOR_PIN_AMT_ADC1];
+
+} __attribute__((packed)); // need this to ensure data is packed without gaps in between;
 
 void Telemetry_Init();
 TelemetryData const* Telemetry_GetData();
+void Telemetry_Init();
+void Telemetry_SerializeData(TelemetryData data, uint8_t* serializedTelemetryBuf);
 void Telemetry_UpdateData(TelemetryData* data);
+void Telemetry_UpdateADCData(volatile uint16_t* adc0reads, volatile uint16_t* adc1reads);
+
 


### PR DESCRIPTION
## Change Description
Merged code from ADC blocking approach into most recent code from mainline. This is an entirely new commit because there were going to be a lot of conflicts if it was a git merge.

## Why the change is needed and implementation details
This ADC approach allows for thread-safe CAN message sending. The thread is locked via mutex when it copies the Telemetry data into a buffer for sending, and the ADC values are read in a separate thread instead of with the ISR approach previously implemented.

## Testing and validation
Blocking code & telemetry CAN messages was tested and verified to work, but this newest version of the code still needs to be tested. 