### PR TITLE
Aw pk/power limiting

### DIFF
--- a/fsae-vehicle-fw/src/utils/utils.h
+++ b/fsae-vehicle-fw/src/utils/utils.h
@@ -93,3 +93,6 @@
 
 #define MAX_REGEN_TORQUE -9.0F // TODO: test with higher value regen
 #define REGEN_BIAS 1 // Scale 0-1 of max regen torque
+
+#define TORQUE_THRESHOLD 90
+#define SOC_THRESHOLD 20

--- a/fsae-vehicle-fw/src/utils/utils.h
+++ b/fsae-vehicle-fw/src/utils/utils.h
@@ -96,3 +96,8 @@
 
 #define TORQUE_THRESHOLD 90
 #define SOC_THRESHOLD 20
+
+#define SOC_START 0.2
+#define SOC_END 0.05
+#define MAX_POWER 80
+

--- a/fsae-vehicle-fw/src/vehicle/motor.cpp
+++ b/fsae-vehicle-fw/src/vehicle/motor.cpp
@@ -173,6 +173,7 @@ void Motor_UpdateMotor(float torqueDemand, bool enablePrecharge, bool enablePowe
                 // to prevent the motor from applying torque in the wrong direction
                 motorData.desiredTorque = MAX_REGEN_TORQUE * REGEN_BIAS;
             } else {
+                // add power-limiting feature with torqueDemand as argument
                 motorData.desiredTorque = torqueDemand;
             }
             #else

--- a/fsae-vehicle-fw/src/vehicle/power_limit.cpp
+++ b/fsae-vehicle-fw/src/vehicle/power_limit.cpp
@@ -3,10 +3,34 @@
 
 float PowerLimit_Update(float soc, float voltage, float current, float driverTorqueCmd){
     float power = voltage * current;
+
+    // 1. Compute torqueLimit using Linear SOC Derating
+    float torqueLimit;
+    if (soc >= SOC_START){
+        torqueLimit = MOTOR_MAX_TORQUE;
+    }
+
+    else if (soc > SOC_END){
+        torqueLimit = (soc - SOC_END)/(SOC_START-SOC_END) * MOTOR_MAX_TORQUE;
+    }
+
+    else{
+        torqueLimit = 0.0f;
+    }
+
+    // 2. Scale torque if electrical power exceeds limit
     if (power > TORQUE_THRESHOLD){ // define constant in utils, currently dummy value
-        return TORQUE_THRESHOLD;
+        driverTorqueCmd *= TORQUE_THRESHOLD / power;
     }
-    else if (soc < SOC_THRESHOLD){
-        return 0;
+
+    // 3. Force driverTorqueCmd to to stay under torque limit
+    if (driverTorqueCmd > torqueLimit){
+        driverTorqueCmd = torqueLimit;
     }
+
+    else if (driverTorqueCmd < -torqueLimit){
+        driverTorqueCmd = -torqueLimit;
+    }
+
+    return driverTorqueCmd;
 }

--- a/fsae-vehicle-fw/src/vehicle/power_limit.cpp
+++ b/fsae-vehicle-fw/src/vehicle/power_limit.cpp
@@ -1,0 +1,12 @@
+#include "power_limit.h"
+#include "utils/utils.h"
+
+float PowerLimit_Update(float soc, float voltage, float current, float driverTorqueCmd){
+    float power = voltage * current;
+    if (power > TORQUE_THRESHOLD){ // define constant in utils, currently dummy value
+        return TORQUE_THRESHOLD;
+    }
+    else if (soc < SOC_THRESHOLD){
+        return 0;
+    }
+}

--- a/fsae-vehicle-fw/src/vehicle/power_limit.h
+++ b/fsae-vehicle-fw/src/vehicle/power_limit.h
@@ -1,0 +1,3 @@
+# pragma once
+
+float PowerLimit_Update(float soc, float voltage, float current, float driverTorqueCmd);


### PR DESCRIPTION
## Change Description
Introducing power limiting features for accumulator based derating and so as to not exceed 80 kW as specified in the fsae rulebook

## Why the change is needed and implementation details
This change is needed to be rules compliant

## Testing and validation
Functions have been tested in code and test cases are outlined in the sharepoint documentation folder. Testing on the actual system has not taken place yet.